### PR TITLE
Feature/114096/minor fixes 20241117

### DIFF
--- a/src/app/users/components/files/files-view/files-view.component.html
+++ b/src/app/users/components/files/files-view/files-view.component.html
@@ -93,8 +93,8 @@
   </div>
 
   
-  <div class="col-12 d-flex justify-content-end">
+  <!-- <div class="col-12 d-flex justify-content-end">
     <button type="submit" class="btn btn-secondary" (click)="goBack()">Volver</button>
-  </div>
+  </div> -->
 </app-main-container>
 

--- a/src/app/users/components/files/files-view/files-view.component.html
+++ b/src/app/users/components/files/files-view/files-view.component.html
@@ -80,7 +80,7 @@
     </table>
   </div>
   
-  <!-- Paginación y elementos por página -->
+  <!-- Paginación y elementos por página
   <div class="d-flex justify-content-between align-items-center mt-3">
     <ngb-pagination
         [(page)]="currentPage"
@@ -90,6 +90,33 @@
         [maxSize]="5"
         [boundaryLinks]="false"
       ></ngb-pagination>
+  </div> -->
+  <div class="d-flex justify-content-between align-items-center mt-3">
+
+    <div class="form-group mb-3 me-2">
+      <select
+        id="itemsPerPage"
+        class="form-select"
+        [(ngModel)]="pageSize"
+        (change)="onItemsPerPageChange()"
+      >
+      @for(option of sizeOptions; track $index) {
+        <option [value]="option">{{ option }} Elementos</option>
+      }
+      </select>
+    </div>
+
+    <div class="ms-auto"></div>
+
+    <ngb-pagination
+    [(page)]="currentPage"
+    [pageSize]="pageSize"
+    [collectionSize]="totalItems"
+    (pageChange)="onPageChange($event)"
+    [maxSize]="5"
+    [boundaryLinks]="false"
+    ></ngb-pagination>
+
   </div>
 
   

--- a/src/app/users/components/files/owner-files-view/owner-files-view.component.html
+++ b/src/app/users/components/files/owner-files-view/owner-files-view.component.html
@@ -113,7 +113,7 @@
                             <li><a class="dropdown-item btn btn-success" (click)="changeFileStatus(file, 'APPROVED')">Aprobar</a></li>
                           }
                           @if(file.approvalStatus === "PRE_APPROVED" || file.approvalStatus === "UPLOADED") {
-                            <li><a class="dropdown-item btn btn-danger" (click)="changeFileStatus(file, 'REVIEWED_WITH_NOTES')">Agregar Nota</a></li>
+                            <li><a class="dropdown-item btn btn-danger" (click)="changeFileStatus(file, 'REVIEWED_WITH_NOTES')">Pedir Corrección</a></li>
                           }
                           @if(file.approvalStatus === "APPROVED") {
                             <li><a class="dropdown-item btn btn-danger" (click)="changeFileStatus(file, 'MODIFICATION_PERMIT_GRANTED')">Permitir Cambio</a></li>

--- a/src/app/users/components/files/owner-files-view/owner-files-view.component.html
+++ b/src/app/users/components/files/owner-files-view/owner-files-view.component.html
@@ -87,7 +87,7 @@
           } @else {
               <thead>
                 <tr>
-                  <th scope="col">Nombre</th>
+                  <!-- <th scope="col">Nombre</th> -->
                   <th scope="col">Tipo</th>
                   <th scope="col">Estado de KYC</th>
                   <th scope="col">Acciones</th>
@@ -96,7 +96,7 @@
               <tbody>
                 @for(file of files; track file) {
                   <tr>
-                    <td>{{ file.name }}</td>
+                    <!-- <td>{{ file.name }}</td> -->
                     <td>{{ translateTable(file.fileType, fileTypeDictionary) }}</td>
                     <td>{{ translateTable(file.approvalStatus, fileStatusDictionary) }}</td>
                     <td>

--- a/src/app/users/components/files/owner-files-view/owner-files-view.component.ts
+++ b/src/app/users/components/files/owner-files-view/owner-files-view.component.ts
@@ -429,15 +429,15 @@ export class OwnerFilesViewComponent implements OnInit {
           {
             strong: 'Pre-Aprobar: ',
             detail:
-              'Abre un modal para poder dejar una observación al archivo y cambiar el estado a "Pre-Aprobado".',
+              'Abre un modal para poder dejar una observación al archivo y cambiar el estado a "Pre-Aprobado". Pre-Aprobado significa que la persona encargada evaluó el archivo de forma digital y decidió que es apto para pasar a la siguiente etapa.',
           },
           {
             strong: 'Aprobar: ',
             detail:
-              'Abre un modal para poder dejar una observación al archivo y cambiar el estado a "Aprobado".',
+              'Abre un modal para poder dejar una observación al archivo y cambiar el estado a "Aprobado". Aprobado significa que la persona encargada se comunicó con el propietario para realizar una reunión donde se evaluaron los documentos de forma física y los consideró aptos.',
           },
           {
-            strong: 'Agregar Nota: ',
+            strong: 'Pedir Corrección: ',
             detail:
               'Abre un modal para poder dejar una observación al archivo y cambiar el estado a "Revisado".',
           },
@@ -454,7 +454,7 @@ export class OwnerFilesViewComponent implements OnInit {
           
           {
             strong: 'Validar Propietario: ',
-            detail: 'Botón azul que permite presionarlo cuando es posible cambiar el estado del Propietario a "Validado". Abre un modal para confirmación.',
+            detail: 'Botón azul que se habilita solo cuando el propietario tiene al menos 2 archivos de DNI (frente y dorso) y un archivo de escritura en estado "Aprobado". Abre un modal para confirmación.',
           },
         ],
       },

--- a/src/app/users/components/forgot-password/forgot-password.component.html
+++ b/src/app/users/components/forgot-password/forgot-password.component.html
@@ -47,7 +47,7 @@
 
                 <div class="col-12 d-flex justify-content-end">
                   <div class="mx-2">
-                      <button type="button" class="btn btn-danger" (click)="cancel()">Volver</button>
+                      <button type="button" class="btn btn-danger" (click)="cancel()">Cancelar</button>
                   </div>
                   <div>
                       <button type="submit" class="btn btn-primary">Continuar</button>


### PR DESCRIPTION
Fix list:

- Vista de Archivos de Propietarios, sacar la columna de nombre del archivo.
- En la pantalla de “Olvido su contraseña?”, El boton “Volver”, deberia ser “Cancelar”
- Vista de Archivos de Propietarios, tiene el paginado al reves. Las flechas van a la derecha, y los “10 Elementos” a la izquierda.
- Cambiar la info del boton de informacion de “Archivos de Propietarios”:
   - Agregar que significa pre-aprobar y aprobar
   - Agregar que el boton de “Validar Propietario” se activa recien cuando tenes 3 archivos aprobados